### PR TITLE
Style fixes & adjustments

### DIFF
--- a/app/src/components/Footer.tsx
+++ b/app/src/components/Footer.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Box, Container, Flex, HStack, Image, Link, Text, Icon, Divider } from "@chakra-ui/react";
+import { Box, Container, Flex, Image, Link, Text, Icon, Divider } from "@chakra-ui/react";
 import { FaGithub } from "react-icons/fa";
 
 const Footer = () => {
@@ -9,6 +9,7 @@ const Footer = () => {
       bgGradient="linear(to-r,rgb(15, 64, 80),rgb(12, 53, 92))"
       color="white"
       py={12}
+      mt={32}
     >
       <Container maxW="container.xl">
         <Flex 
@@ -91,7 +92,7 @@ const Footer = () => {
             direction="column" 
             align={{ base: "center", md: "start" }} 
             gap={6}
-            pl={{ base: 0, md: 8 }}  // Reduced left padding to accommodate divider
+            pl={{ base: 0, md: 8 }} 
             maxW={{ base: "100%", md: "45%" }}
           >
             <Box width="100%">

--- a/app/src/components/Footer.tsx
+++ b/app/src/components/Footer.tsx
@@ -9,7 +9,7 @@ const Footer = () => {
       bgGradient="linear(to-r,rgb(15, 64, 80),rgb(12, 53, 92))"
       color="white"
       py={12}
-      mt={32}
+      mt={32} // So genius I forgot to add this
     >
       <Container maxW="container.xl">
         <Flex 
@@ -56,6 +56,22 @@ const Footer = () => {
                 px={{ base: 4, md: 0 }}
               >
                 Learn trading by experience, without the cost.
+              </Text>
+              <Text 
+                fontSize={{ base: "md", md: "m" }} 
+                color="gray.300"
+                ml={{ base: 0, md: 3 }}
+                px={{ base: 4, md: 0 }}
+                mt={12}
+              >
+                Found a bug or need help? Contact us{" "}
+                <Link
+                  href="mailto:anas.timeridjine@gmail.com" // Can't wait to get ~200 emails
+                  color="blue.300"
+                  _hover={{ color: "blue.200" }}
+                >
+                  here.
+                </Link>
               </Text>
             </Flex>
           </Box>

--- a/app/src/components/Newsfeed.tsx
+++ b/app/src/components/Newsfeed.tsx
@@ -8,7 +8,6 @@ import {
   Heading,
   Stack,
   Link,
-  Spinner,
   useTheme,
   CardFooter,
   Tag,
@@ -16,6 +15,7 @@ import {
   Image,
 } from "@chakra-ui/react";
 import axios from "axios";
+import NewsCardSkeleton from "./skeletons/NewsCardSkeleton";
 
 interface NewsItem {
   title: string;
@@ -87,9 +87,14 @@ function Newsfeed(props: { symbol?: string }) {
 
   if (isLoading) {
     return (
-      <Stack align="center" justify="center" h="100%">
-        <Spinner />
-      </Stack>
+      <SimpleGrid
+        spacing={1}
+        templateColumns="repeat(auto-fill, minmax(250px, 1fr))"
+        gap={5}>
+        {[...Array(9)].map((_, i) => (
+          <NewsCardSkeleton key={i} />
+        ))}
+      </SimpleGrid>
     );
   }
 
@@ -97,8 +102,7 @@ function Newsfeed(props: { symbol?: string }) {
     <SimpleGrid
       spacing={1}
       templateColumns="repeat(auto-fill, minmax(250px, 1fr))"
-      gap={5}
-    >
+      gap={5}>
       {news.map((item) => (
         <Card maxW="sm" h="100%" key={item.title}>
           <CardHeader fontSize="sm" pb={2} display="flex" gap="2">
@@ -108,8 +112,7 @@ function Newsfeed(props: { symbol?: string }) {
               fontWeight="500"
               textOverflow="ellipsis"
               overflow="hidden"
-              whiteSpace="nowrap"
-            >
+              whiteSpace="nowrap">
               {item.source}
             </Text>
           </CardHeader>
@@ -117,8 +120,7 @@ function Newsfeed(props: { symbol?: string }) {
             href={item.sourceUrl}
             color="inherit"
             isExternal
-            _hover={{ textDecoration: "none" }}
-          >
+            _hover={{ textDecoration: "none" }}>
             <CardBody pt={0} h="100%">
               <HStack align="flex-start" spacing={4}>
                 <Stack flex="1">
@@ -127,8 +129,7 @@ function Newsfeed(props: { symbol?: string }) {
                     textOverflow="ellipsis"
                     display="-webkit-box"
                     overflow="hidden"
-                    css="-webkit-line-clamp: 3; -webkit-box-orient: vertical;"
-                  >
+                    css="-webkit-line-clamp: 3; -webkit-box-orient: vertical;">
                     {item.title}
                   </Heading>
                   <Text
@@ -136,8 +137,7 @@ function Newsfeed(props: { symbol?: string }) {
                     textOverflow="ellipsis"
                     display="-webkit-box"
                     overflow="hidden"
-                    css="-webkit-line-clamp: 6; -webkit-box-orient: vertical;"
-                  >
+                    css="-webkit-line-clamp: 6; -webkit-box-orient: vertical;">
                     {item.description}
                   </Text>
                 </Stack>
@@ -165,8 +165,7 @@ function Newsfeed(props: { symbol?: string }) {
                     href={`/stocks/${symbol}`}
                     key={symbol}
                     colorScheme={accentColor}
-                    size="sm"
-                  >
+                    size="sm">
                     {symbol}
                   </Tag>
                 ))}

--- a/app/src/components/skeletons/LeaderboardSkeleton.tsx
+++ b/app/src/components/skeletons/LeaderboardSkeleton.tsx
@@ -1,0 +1,51 @@
+// Spooky, scary skeletons
+// Send shivers down your spine
+// Shrieking skulls will shock your soul
+// Seal your doom tonight
+
+import React from "react";
+import {
+  Box,
+  Skeleton,
+  Table,
+  Tbody,
+  Td,
+  Th,
+  Thead,
+  Tr,
+} from "@chakra-ui/react";
+
+const LeaderboardSkeleton = () => {
+  return (
+    <Box>
+      <Skeleton height="36px" width="200px" mx="auto" mb={4} />
+      <Skeleton height="40px" width="50%" mx="auto" mb={4} />
+      <Table variant="simple" colorScheme="gray">
+        <Thead>
+          <Tr>
+            <Th p={{ base: 2, md: 4 }}>Rank</Th>
+            <Th p={{ base: 2, md: 4 }}>Username</Th>
+            <Th p={{ base: 2, md: 4 }}>Portfolio Value</Th>
+          </Tr>
+        </Thead>
+        <Tbody>
+          {[...Array(10)].map((_, index) => (
+            <Tr key={index}>
+              <Td p={{ base: 2, md: 4 }}>
+                <Skeleton height="20px" width="30px" />
+              </Td>
+              <Td p={{ base: 2, md: 4 }}>
+                <Skeleton height="20px" width="120px" />
+              </Td>
+              <Td p={{ base: 2, md: 4 }}>
+                <Skeleton height="20px" width="100px" />
+              </Td>
+            </Tr>
+          ))}
+        </Tbody>
+      </Table>
+    </Box>
+  );
+};
+
+export default LeaderboardSkeleton;

--- a/app/src/components/skeletons/NewsCardSkeleton.tsx
+++ b/app/src/components/skeletons/NewsCardSkeleton.tsx
@@ -1,0 +1,26 @@
+// Spooky, scary skeletons
+// Speak with such a screech
+// You'll shake and shudder in surprise
+// When you hear these zombies shriek
+
+import { Card, CardBody, CardHeader, Skeleton, SkeletonText, Stack } from "@chakra-ui/react";
+import React from "react";
+
+const NewsCardSkeleton = () => {
+  return (
+    <Card maxW="sm" h="100%">
+      <CardHeader fontSize="sm" pb={2} display="flex" gap="2">
+        <Skeleton height="20px" width="100px" />
+        <Skeleton height="20px" width="80px" />
+      </CardHeader>
+      <CardBody pt={0}>
+        <Stack spacing={4}>
+          <Skeleton height="60px" />
+          <SkeletonText mt="4" noOfLines={4} spacing="4" skeletonHeight="2" />
+        </Stack>
+      </CardBody>
+    </Card>
+  );
+};
+
+export default NewsCardSkeleton;

--- a/app/src/components/skeletons/StockProfileSkeleton.tsx
+++ b/app/src/components/skeletons/StockProfileSkeleton.tsx
@@ -1,0 +1,30 @@
+// We're sorry, skeletons, you're so misunderstood
+// You only want to socialize (but I don't think we should)
+
+// 'Cause spooky, scary skeletons
+// Shout startling, shrilly screams
+// They'll sneak from their sarcophagus
+// And just won't leave you be
+
+import { Box, Flex, Skeleton, SkeletonText, Stack } from "@chakra-ui/react";
+import React from "react";
+
+const StockProfileSkeleton = () => {
+  return (
+    <Box width="100%">
+      <Flex justifyContent="space-between" alignItems="center" mb={4}>
+        <Stack width="100%">
+          <Skeleton height="40px" width="200px" />
+          <Skeleton height="24px" width="150px" />
+        </Stack>
+        <Skeleton height="40px" width="180px" />
+      </Flex>
+      <Skeleton height="600px" width="100%" />
+      <Box mt={4}>
+        <SkeletonText mt="4" noOfLines={6} spacing="4" skeletonHeight="2" />
+      </Box>
+    </Box>
+  );
+};
+
+export default StockProfileSkeleton;

--- a/app/src/pages/HeroPage.tsx
+++ b/app/src/pages/HeroPage.tsx
@@ -1,4 +1,5 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
+import { motion } from 'framer-motion';
 import TickerTapeScript from '../components/tickerTapeScript';
 import {
   Box,
@@ -9,180 +10,214 @@ import {
   Image,
   VStack,
   Button,
+  keyframes,
 } from "@chakra-ui/react";
 import { useNavigate } from 'react-router-dom';
 
+// Create motion components
+const MotionBox = motion(Box);
+const MotionFlex = motion(Flex);
+
+//cursor pulse animation
+const cursorPulse = keyframes`
+  0% { border-right-color: #4cd6e9 }
+  50% { border-right-color: transparent }
+  100% { border-right-color: #4cd6e9 }
+`;
+
+function useTypewriter(text: string, speed: number = 150) {
+  const [displayText, setDisplayText] = useState('');
+
+  useEffect(() => {
+    let i = 0;
+    const timer = setInterval(() => {
+      if (i < text.length) {
+        setDisplayText(prev => prev + text.charAt(i));
+        i++;
+      } else {
+        clearInterval(timer);
+      }
+    }, speed);
+
+    return () => clearInterval(timer);
+  }, [text, speed]);
+
+  return displayText;
+}
+
 export default function HeroPage() {
   const navigate = useNavigate();
+  const displayText = useTypewriter('Stoockish', 100); // Sorry I had to add the extra O or else the heading becomes "Stckish" :/
+
+  const fadeInVariant = {
+    hidden: { opacity: 0, y: 20 },
+    visible: { opacity: 1, y: 0 }
+  };
+
+  const cursorAnimation = `${cursorPulse} 1.1s infinite`;
 
   return (
     <Box>
       <TickerTapeScript />
       
       <Container maxW="container.xl" px={5}>
-        <VStack spacing={4} align="center" mt={100}>
-
-          <Flex
-            width="100%"
-            justifyContent="center"
-            alignItems="center"
-            position="relative"
-          >
+        <MotionFlex
+          initial="hidden"
+          animate="visible"
+          variants={fadeInVariant}
+          transition={{ duration: 0.6 }}
+          width="100%"
+          justifyContent="center"
+          alignItems="center"
+          position="relative"
+          mt={100}
+        >
+          <Box display="flex" alignItems="center">
             <Image
               src="/Logo.svg"
               alt="Stockish Logo"
               boxSize={{ base: "70px", md: "140px" }}
-              mr={{ base: 5, md: 18 }}
             />
-            <Heading
-              as="h1"
-              size="4xl"
-              fontSize={{ base: "6xl", md: "9xl" }}
-              fontWeight={"extrabold"}
+            <Box
+              textAlign="left"
+              minWidth={{ base: "8ch", md: "10ch" }}
+              ml={{ base: 5, md: 18 }}
+              style={{ borderRight: '4px solid #4cd6e9', paddingRight: '4px' }}
+              animation={cursorAnimation}
             >
-              Stockish
-            </Heading>
-          </Flex>
-          
-          <Text
-            fontSize="2xl"
-            fontWeight="semibold"
-            textAlign="center"
-            mt={0}
+              <Heading
+                as="h1"
+                size="4xl"
+                fontSize={{ base: "6xl", md: "9xl" }}
+                fontWeight="extrabold"
+              >
+                {displayText}
+              </Heading>
+            </Box>
+          </Box>
+        </MotionFlex>
+
+        <Text
+          fontSize="2xl"
+          fontWeight="semibold"
+          textAlign="center"
+          mt={0}
+        >
+          THE platform to kickstart your stock trading journey
+        </Text>
+
+        {[1, 2, 3, 4].map((index) => (
+          <MotionFlex
+            key={index}
+            initial="hidden"
+            whileInView="visible"
+            viewport={{ once: true, margin: "-100px" }}
+            variants={fadeInVariant}
+            transition={{ duration: 0.6 }}
+            mt={index === 1 ? 40 : 20}
+            gap={16}
+            direction={{ base: 'column', md: 'row' }}
+            align="center"
           >
-            THE platform to kickstart your stock trading journey
-          </Text>
-        </VStack>
+            {index % 2 === 1 ? (
+              <>
+                <MotionBox flex="1" variants={fadeInVariant}>
+                  {index === 1 && (
+                    <>
+                      <Heading
+                        as="h2"
+                        size="lg"
+                        mb={4}
+                      >
+                        › Learn by experience, without the cost
+                      </Heading>
+                      <Text fontSize="lg" color="gray.600">
+                        <Text as="span" fontWeight="bold">
+                          We believe the best way to learn trading is by practicing it and going hands-on.
+                        </Text>
+                        {" "}For “Experience is the best teacher”; and we’ve followed this quote by providing you with a stock simulator with virtual money, connected to the real worldwide stock market, so that you can experiment and be able to go through any bumpy roads on your way to becoming a trading master without making any financial loss!
+                      </Text>
+                    </>
+                  )}
+                  {index === 3 && (
+                    <>
+                      <Heading
+                        as="h2"
+                        size="lg"
+                        mb={4}
+                      >
+                        Data from the most reliable sources
+                      </Heading>
+                      <Text fontSize="lg" color="gray.600">
+                        To be a good trader, you gotta make sure you have the fastest, most accurate data. We’ve got you covered - we get our stock data from TradingView, and news from Yahoo Finance, so you can always stay in sync with how the market is going and become a very competitive trader.
+                      </Text>
+                    </>
+                  )}
+                </MotionBox>
+                <MotionBox flex="1" variants={fadeInVariant}>
+                  <Image
+                    src={`/Showcase${index}.png`}
+                    alt={`Showcase ${index}`}
+                    borderRadius="lg"
+                    objectFit="cover"
+                    width="100%"
+                    height="auto"
+                  />
+                </MotionBox>
+              </>
+            ) : (
+              <>
+                <MotionBox flex="1" variants={fadeInVariant}>
+                  <Image
+                    src={`/Showcase${index}.png`}
+                    alt={`Showcase ${index}`}
+                    borderRadius="lg"
+                    objectFit="cover"
+                    width="100%"
+                    height="auto"
+                  />
+                </MotionBox>
+                <MotionBox flex="1" variants={fadeInVariant}>
+                  {index === 2 && (
+                    <>
+                      <Heading
+                        as="h2"
+                        size="lg"
+                        mb={4}
+                      >
+                        For students, By students
+                      </Heading>
+                      <Text fontSize="lg" color="gray.600">
+                        We know understanding the market and being a good trader is hard. So we’ve got you equipped with lots of tutorials and articles we recommend you check out, along with resources to help you find out which stocks are the best to invest in.
+                      </Text>
+                    </>
+                  )}
+                  {index === 4 && (
+                    <>
+                      <Heading
+                        as="h2"
+                        size="lg"
+                        mb={4}
+                      >
+                        No risk - high reward
+                      </Heading>
+                      <Text fontSize="lg" color="gray.600">
+                        We’ve also got a leaderboard where everyone can compete against each other and see who earns the most money, so that you won’t just earn bragging rights and trading experience if you win, but real monetary rewards for your hard work!
+                      </Text>
+                    </>
+                  )}
+                </MotionBox>
+              </>
+            )}
+          </MotionFlex>
+        ))}
 
-        <Flex
-          mt={40}
-          gap={16}
-          direction={{ base: 'column', md: 'row' }}
-          align="center"
-        >
-          <Box flex="1">
-            <Heading
-              as="h2"
-              size="lg"
-              mb={4}
-            >
-            › Learn by experience, without the cost
-            </Heading>
-            <Text fontSize="lg" color="gray.600">
-            <Text as="span" fontWeight="bold">
-              We believe the best way to learn trading is by practicing it and going hands-on.
-            </Text>
-            {" "}For “Experience is the best teacher”; and we’ve followed this quote by providing you with a stock simulator with virtual money, connected to the real worldwide stock market, so that you can experiment and be able to go through any bumpy roads on your way to becoming a trading master without making any financial loss!
-          </Text>
-          </Box>
-
-          <Box flex="1">
-            <Image
-              src="/Showcase1.png"
-              alt="Homepage & Markets Showcase"
-              borderRadius="lg"
-              objectFit="cover"
-              width="100%"
-              height="auto"
-            />
-          </Box>
-        </Flex>
-
-        
-        <Flex
-          mt={20}
-          gap={16}
-          direction={{ base: 'column', md: 'row' }}
-          align="center"
-        >
-          <Box flex="1">
-            <Image
-              src="/Showcase2.png"
-              alt="How to trade Page Showcase"
-              borderRadius="lg"
-              objectFit="cover"
-              width="100%"
-              height="auto"
-            />
-          </Box>
-
-          <Box flex="1">
-            <Heading
-              as="h2"
-              size="lg"
-              mb={4}
-            >
-              For students, By students
-            </Heading>
-            <Text fontSize="lg" color="gray.600">
-            We know understanding the market and being a good trader is hard. So we’ve got you equipped with lots of tutorials and articles we recommend you check out, along with resources to help you find out which stocks are the best to invest in.
-            </Text>
-          </Box>
-        </Flex>
-
-        <Flex
-          mt={20}
-          gap={16}
-          direction={{ base: 'column', md: 'row' }}
-          align="center"
-        >
-          <Box flex="1">
-            <Heading
-              as="h2"
-              size="lg"
-              mb={4}
-            >
-              Data from the most reliable sources
-            </Heading>
-            <Text fontSize="lg" color="gray.600">
-            To be a good trader, you gotta make sure you have the fastest, most accurate data. We’ve got you covered - we get our stock data from TradingView, and news from Yahoo Finance, so you can always stay in sync with how the market is going and become a very competitive trader.
-            </Text>
-          </Box>
-
-          <Box flex="1">
-            <Image
-              src="/Showcase3.png"
-              alt="Stock Chart showcase"
-              borderRadius="lg"
-              objectFit="cover"
-              width="100%"
-              height="auto"
-            />
-          </Box>
-        </Flex>
-
-        <Flex
-          mt={20}
-          gap={16}
-          direction={{ base: 'column', md: 'row' }}
-          align="center"
-        >
-          <Box flex="1">
-            <Image
-              src="/Showcase4.png"
-              alt="Leaderboard Showcase"
-              borderRadius="lg"
-              objectFit="cover"
-              width="100%"
-              height="auto"
-            />
-          </Box>
-
-          <Box flex="1">
-            <Heading
-              as="h2"
-              size="lg"
-              mb={4}
-            >
-              No risk - high reward
-            </Heading>
-            <Text fontSize="lg" color="gray.600">
-            We’ve also got a leaderboard where everyone can compete against each other and see who earns the most money, so that you won’t just earn bragging rights and trading experience if you win, but real monetary rewards for your hard work!
-            </Text>
-          </Box>
-        </Flex>
-
-        <Box
+        <MotionBox
+          initial="hidden"
+          whileInView="visible"
+          viewport={{ once: true, margin: "-100px" }}
+          variants={fadeInVariant}
+          transition={{ duration: 0.6 }}
           mt={40}
           mb={20}
           py={20}
@@ -217,7 +252,7 @@ export default function HeroPage() {
               Create an account
             </Button>
           </VStack>
-        </Box>
+        </MotionBox>
       </Container>
     </Box>
   );

--- a/app/src/pages/Leaderboard.tsx
+++ b/app/src/pages/Leaderboard.tsx
@@ -13,6 +13,7 @@ import {
 	Tr,
 	useTheme,
 } from "@chakra-ui/react";
+import LeaderboardSkeleton from "../components/skeletons/LeaderboardSkeleton";
 
 interface LeaderboardUser {
 	username: string;
@@ -27,6 +28,7 @@ const format = new Intl.NumberFormat("en-US", {
 function Leaderboard() {
 	const [leaderboard, setLeaderboard] = useState<LeaderboardUser[]>([]);
 	const [searchQuery, setSearchQuery] = useState("");
+	const [isLoading, setIsLoading] = useState(true);
 
 	// Use theme for accent color
 	let accentColor =
@@ -34,13 +36,18 @@ function Leaderboard() {
 
 	// Function to fetch leaderboard data
 	const fetchLeaderboard = () => {
+		setIsLoading(true);
 		axios
 			.get(`/api/user/leaderboard?timestamp=${Date.now()}`)
 			.then((res) => {
 				setLeaderboard(res.data.users);
+				setIsLoading(false);
 				console.log("Fetched leaderboard data:", res.data.users);
 			})
-			.catch((err) => console.log("Error fetching leaderboard data:", err));
+			.catch((err) => {
+				console.log("Error fetching leaderboard data:", err);
+				setIsLoading(false);
+			});
 	};
 
 	// Fetch data when the component mounts and set up periodic updates
@@ -62,6 +69,10 @@ function Leaderboard() {
 	const filteredLeaderboard = leaderboard.filter((user) =>
 		user.username.toLowerCase().includes(searchQuery.toLowerCase())
 	);
+
+	if (isLoading) {
+		return <LeaderboardSkeleton />;
+	}
 
 	return (
 		<Box className="leaderboard">

--- a/app/src/pages/StockView.tsx
+++ b/app/src/pages/StockView.tsx
@@ -1,15 +1,6 @@
 import React, { useEffect, useReducer, useState } from "react";
 import { useLocation, useParams } from "react-router-dom";
-import {
-
-	Heading,
-	Spacer,
-	Flex,
-	Box,
-	Button,
-	Spinner,
-
-} from "@chakra-ui/react";
+import { Heading, Spacer, Flex, Box, Button } from "@chakra-ui/react";
 import axios from "axios";
 import symbolMap from "../../../server/src/utils/symbolMap";
 import SymbolProfileWidget from "../components/SymbolProfile";
@@ -19,137 +10,128 @@ import Newsfeed from "../components/Newsfeed";
 import TransactionPane from "../components/TransactionPane";
 import StockChart from "../components/StockChart";
 import SymbolInfoWidget from "../components/SymbolInfo";
+import StockProfileSkeleton from "../components/skeletons/StockProfileSkeleton";
 
-import {
-	AddIcon,
-
-	MinusIcon,
-} from "@chakra-ui/icons";
-
-
+import { AddIcon, MinusIcon } from "@chakra-ui/icons";
 
 function StockView() {
-	const { symbol } = useParams();
-	const location = useLocation();
-	const mappedSymbol = symbol ? (symbolMap[symbol] || symbol) : "";
+  const { symbol } = useParams();
+  const location = useLocation();
+  const mappedSymbol = symbol ? symbolMap[symbol] || symbol : "";
 
-	const [onWatchlist, setOnWatchlist] = useState(false);
+  const [onWatchlist, setOnWatchlist] = useState(false);
 
-	const [stock, setStock] = useReducer(
-		(state: any, newState: any) => ({ ...state, ...newState }),
-		{
-			symbol: mappedSymbol,
-			longName: "",
-			regularMarketPrice: -1,
-			regularMarketChangePercent: 0,
-		},
-	);
+  const [stock, setStock] = useReducer(
+    (state: any, newState: any) => ({ ...state, ...newState }),
+    {
+      symbol: mappedSymbol,
+      longName: "",
+      regularMarketPrice: -1,
+      regularMarketChangePercent: 0,
+    }
+  );
 
-	useEffect(() => {
-		// Check if stock is on watchlist
-		if (tokens.isAuthenticated()) {
-			accounts.getWatchlist(true).then((res: any[]) => {
-				setOnWatchlist(res.some((stock) => stock.symbol === symbol));
-			});
-		}
+  useEffect(() => {
+    // Check if stock is on watchlist
+    if (tokens.isAuthenticated()) {
+      accounts.getWatchlist(true).then((res: any[]) => {
+        setOnWatchlist(res.some((stock) => stock.symbol === symbol));
+      });
+    }
 
-		axios
-			.get(`/api/stocks/${symbol}/info`)
-			.then((res) => {
-				setStock({ ...res.data });
-			})
-			.catch((err) => {
-				console.log(err);
-			});
-	}, [location]);
+    axios
+      .get(`/api/stocks/${symbol}/info`)
+      .then((res) => {
+        setStock({ ...res.data });
+      })
+      .catch((err) => {
+        console.log(err);
+      });
+  }, [location]);
 
-	if (stock.regularMarketPrice < 0) {
-		return (
-			<Flex justifyContent="center">
-				<Spinner size="xl" />
-			</Flex>
-		);
-	}
+  if (stock.regularMarketPrice < 0) {
+    return <StockProfileSkeleton />;
+  }
 
-	return (
-		<>
-			{stock.regularMarketPrice > 0 && (
-				<Flex direction={{ base: "column", md: "row" }} width="100%" gap={4}>
-					<Box width="100%">
-						<Flex justifyContent="space-between" alignItems="center" mb={4}>
-							<Box flex="2" width="100%">
-								<SymbolInfoWidget symbol={mappedSymbol} width="100%" />
-							</Box>
-							{tokens.isAuthenticated() &&
-								(onWatchlist ? (
-									<Button
-										leftIcon={<MinusIcon />}
-										variant={"outline"}
-										onClick={() =>
-											accounts
-												.editWatchlist(symbol as string, "remove")
-												.then(() => setOnWatchlist(false))
-										}
-									>
-										Remove from Watchlist
-									</Button>
-								) : (
-									<Button
-										leftIcon={<AddIcon />}
-										variant={"outline"}
-										onClick={() =>
-											accounts
-												.editWatchlist(symbol as string, "add")
-												.then(() => setOnWatchlist(true))
-										}
-									>
-										Add to Watchlist
-									</Button>
-								))}
-						</Flex>
+  return (
+    <>
+      {stock.regularMarketPrice > 0 && (
+        <Flex direction={{ base: "column", md: "row" }} width="100%" gap={4}>
+          <Box width="100%">
+            <Flex justifyContent="space-between" alignItems="center" mb={4}>
+              <Box flex="2" width="100%">
+                <SymbolInfoWidget symbol={mappedSymbol} width="100%" />
+              </Box>
+              {tokens.isAuthenticated() &&
+                (onWatchlist ? (
+                  <Button
+                    leftIcon={<MinusIcon />}
+                    variant={"outline"}
+                    onClick={() =>
+                      accounts
+                        .editWatchlist(symbol as string, "remove")
+                        .then(() => setOnWatchlist(false))
+                    }>
+                    Remove from Watchlist
+                  </Button>
+                ) : (
+                  <Button
+                    leftIcon={<AddIcon />}
+                    variant={"outline"}
+                    onClick={() =>
+                      accounts
+                        .editWatchlist(symbol as string, "add")
+                        .then(() => setOnWatchlist(true))
+                    }>
+                    Add to Watchlist
+                  </Button>
+                ))}
+            </Flex>
 
-						{/* Stock Chart */}
-						<Box
-							width="100%"
-							height="600px" // Ensure height is set correctly
-							mb={4}
-							minWidth="800px" // Set minimum width
-						>
-							<StockChart
-								symbol={symbol as string}								
-								width="100%"
-								height="100%" // Ensure height is set correctly
-							/>
-						</Box>
+            {/* Stock Chart */}
+            <Box
+              width="100%"
+              height="600px" // Ensure height is set correctly
+              mb={4}
+              minWidth="800px" // Set minimum width
+            >
+              <StockChart
+                symbol={symbol as string}
+                width="100%"
+                height="100%" // Ensure height is set correctly
+              />
+            </Box>
 
-						{/* Symbol Profile */}
-						<Box mt={2}>
-							<SymbolProfileWidget
-								symbol={symbol as string}
-								width="100%"
-								height="400"
-							/>
-						</Box>
-					</Box>
+            {/* Symbol Profile */}
+            <Box mt={2}>
+              <SymbolProfileWidget
+                symbol={symbol as string}
+                width="100%"
+                height="400"
+              />
+            </Box>
+          </Box>
 
-					{/* Transaction Pane */}
-					{tokens.isAuthenticated() && (
-						<Box width="300px" flexShrink={0}>
-							<TransactionPane
-								symbol={symbol as string}
-								price={stock.regularMarketPrice}
-							/>
-						</Box>
-					)}
-				</Flex>
-			)}
+          {/* Transaction Pane */}
+          {tokens.isAuthenticated() && (
+            <Box width="300px" flexShrink={0}>
+              <TransactionPane
+                symbol={symbol as string}
+                price={stock.regularMarketPrice}
+              />
+            </Box>
+          )}
+        </Flex>
+      )}
 
-			{/* News Section - Outside the main Flex container */}
-			<Heading size="md" mt={5}>{symbol as string} News</Heading>
-			<Spacer height={3} />
-			<Newsfeed symbol={symbol as string} />
-		</>
-	);
+      {/* News Section - Outside the main Flex container */}
+      <Heading size="md" mt={5}>
+        {symbol as string} News
+      </Heading>
+      <Spacer height={3} />
+      <Newsfeed symbol={symbol as string} />
+    </>
+  );
 }
 
 export default StockView;

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
             "hasInstallScript": true,
             "dependencies": {
                 "@chakra-ui/react": "^3.5.1",
+                "@chakra-ui/react-utils": "^2.0.11",
                 "@types/react": "^19.0.8",
                 "axios": "^1.7.9",
                 "bcryptjs": "^2.4.3",
@@ -22,6 +23,7 @@
                 "express": "^4.21.2",
                 "express-rate-limit": "^7.5.0",
                 "financial-news-api": "^1.0.0",
+                "framer-motion": "^12.0.6",
                 "highcharts": "^12.1.2",
                 "jsonwebtoken": "^9.0.2",
                 "mercedlogger": "^1.0.1",
@@ -499,6 +501,30 @@
                 "@emotion/react": ">=11",
                 "react": ">=18",
                 "react-dom": ">=18"
+            }
+        },
+        "node_modules/@chakra-ui/react-utils": {
+            "version": "2.0.11",
+            "resolved": "https://registry.npmjs.org/@chakra-ui/react-utils/-/react-utils-2.0.11.tgz",
+            "integrity": "sha512-LdE0Ay5Em2ew7fuux9MJAwaxoaU/QwVoH/t6uiUw/JCWpmiMGY6tw6t3eZTvZSRZNfyPWY0MmvOHR1UvIS9JIw==",
+            "license": "MIT",
+            "dependencies": {
+                "@chakra-ui/utils": "2.0.14"
+            },
+            "peerDependencies": {
+                "react": ">=18"
+            }
+        },
+        "node_modules/@chakra-ui/utils": {
+            "version": "2.0.14",
+            "resolved": "https://registry.npmjs.org/@chakra-ui/utils/-/utils-2.0.14.tgz",
+            "integrity": "sha512-vYxtAUPY09Ex2Ae2ZvQKA1d2+lMKq/wUaRiqpwmeLfutEQuPQZc3qzQcAIMRQx3wLgXr9BUFDtHgBoOz0XKtZw==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/lodash.mergewith": "4.6.6",
+                "css-box-model": "1.2.1",
+                "framesync": "6.1.2",
+                "lodash.mergewith": "4.6.2"
             }
         },
         "node_modules/@cspotcode/source-map-support": {
@@ -1893,6 +1919,21 @@
             "dependencies": {
                 "@types/ms": "*",
                 "@types/node": "*"
+            }
+        },
+        "node_modules/@types/lodash": {
+            "version": "4.17.15",
+            "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.15.tgz",
+            "integrity": "sha512-w/P33JFeySuhN6JLkysYUK2gEmy9kHHFN7E8ro0tkfmlDOgxBDzWEZ/J8cWA+fHqFevpswDTFZnDx+R9lbL6xw==",
+            "license": "MIT"
+        },
+        "node_modules/@types/lodash.mergewith": {
+            "version": "4.6.6",
+            "resolved": "https://registry.npmjs.org/@types/lodash.mergewith/-/lodash.mergewith-4.6.6.tgz",
+            "integrity": "sha512-RY/8IaVENjG19rxTZu9Nukqh0W2UrYgmBj5sdns4hWRZaV8PqR7wIKHFKzvOTjo4zVRV7sVI+yFhAJql12Kfqg==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/lodash": "*"
             }
         },
         "node_modules/@types/mime": {
@@ -3600,6 +3641,15 @@
                 "node": ">= 8"
             }
         },
+        "node_modules/css-box-model": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/css-box-model/-/css-box-model-1.2.1.tgz",
+            "integrity": "sha512-a7Vr4Q/kd/aw96bnJG332W9V9LkJO69JRcaCYDUqjp6/z0w6VcZjgAcTbgFxEPfBgdnAwlh3iwu+hLopa+flJw==",
+            "license": "MIT",
+            "dependencies": {
+                "tiny-invariant": "^1.0.6"
+            }
+        },
         "node_modules/css-color-keywords": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/css-color-keywords/-/css-color-keywords-1.0.0.tgz",
@@ -4423,6 +4473,48 @@
             "engines": {
                 "node": ">= 0.6"
             }
+        },
+        "node_modules/framer-motion": {
+            "version": "12.0.6",
+            "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.0.6.tgz",
+            "integrity": "sha512-LmrXbXF6Vv5WCNmb+O/zn891VPZrH7XbsZgRLBROw6kFiP+iTK49gxTv2Ur3F0Tbw6+sy9BVtSqnWfMUpH+6nA==",
+            "license": "MIT",
+            "dependencies": {
+                "motion-dom": "^12.0.0",
+                "motion-utils": "^12.0.0",
+                "tslib": "^2.4.0"
+            },
+            "peerDependencies": {
+                "@emotion/is-prop-valid": "*",
+                "react": "^18.0.0 || ^19.0.0",
+                "react-dom": "^18.0.0 || ^19.0.0"
+            },
+            "peerDependenciesMeta": {
+                "@emotion/is-prop-valid": {
+                    "optional": true
+                },
+                "react": {
+                    "optional": true
+                },
+                "react-dom": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/framesync": {
+            "version": "6.1.2",
+            "resolved": "https://registry.npmjs.org/framesync/-/framesync-6.1.2.tgz",
+            "integrity": "sha512-jBTqhX6KaQVDyus8muwZbBeGGP0XgujBRbQ7gM7BRdS3CadCZIHiawyzYLnafYcvZIh5j8WE7cxZKFn7dXhu9g==",
+            "license": "MIT",
+            "dependencies": {
+                "tslib": "2.4.0"
+            }
+        },
+        "node_modules/framesync/node_modules/tslib": {
+            "version": "2.4.0",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+            "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
+            "license": "0BSD"
         },
         "node_modules/fresh": {
             "version": "0.5.2",
@@ -5356,6 +5448,21 @@
             "engines": {
                 "node": ">= 0.8"
             }
+        },
+        "node_modules/motion-dom": {
+            "version": "12.0.0",
+            "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.0.0.tgz",
+            "integrity": "sha512-CvYd15OeIR6kHgMdonCc1ihsaUG4MYh/wrkz8gZ3hBX/uamyZCXN9S9qJoYF03GqfTt7thTV/dxnHYX4+55vDg==",
+            "license": "MIT",
+            "dependencies": {
+                "motion-utils": "^12.0.0"
+            }
+        },
+        "node_modules/motion-utils": {
+            "version": "12.0.0",
+            "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-12.0.0.tgz",
+            "integrity": "sha512-MNFiBKbbqnmvOjkPyOKgHUp3Q6oiokLkI1bEwm5QA28cxMZrv0CbbBGDNmhF6DIXsi1pCQBSs0dX8xjeER1tmA==",
+            "license": "MIT"
         },
         "node_modules/mpath": {
             "version": "0.9.0",
@@ -6647,6 +6754,12 @@
             "dev": true,
             "license": "MIT",
             "peer": true
+        },
+        "node_modules/tiny-invariant": {
+            "version": "1.3.3",
+            "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+            "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
+            "license": "MIT"
         },
         "node_modules/to-regex-range": {
             "version": "5.0.1",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     },
     "dependencies": {
         "@chakra-ui/react": "^3.5.1",
+        "@chakra-ui/react-utils": "^2.0.11",
         "@types/react": "^19.0.8",
         "axios": "^1.7.9",
         "bcryptjs": "^2.4.3",
@@ -22,6 +23,7 @@
         "express": "^4.21.2",
         "express-rate-limit": "^7.5.0",
         "financial-news-api": "^1.0.0",
+        "framer-motion": "^12.0.6",
         "highcharts": "^12.1.2",
         "jsonwebtoken": "^9.0.2",
         "mercedlogger": "^1.0.1",


### PR DESCRIPTION
## style(HeroPage): added typewriter effect to heading & fade-ins upon scroll
Self-Explanatory. This was added for the sake of making things look more appealing. **Framer Motion** was used, so there might be an addition in `package.json`. See `HeroPage.tsx` for the additions. Mind the double commit. 

## feat(Leaderboard, Dashboard, Markets): added skeletons
I chose to go with using skeletons instead of loading spinners to keep the footer on the bottom of the page at all times. This was especially added for the Leaderboard and Dashboard, as the Footer was placed too high before the data loaded. 

![image](https://github.com/user-attachments/assets/e91fc0b3-36dc-4e05-9225-d3276af4563e)
^ Leaderboard skeleton

![image](https://github.com/user-attachments/assets/c311832f-677d-45c6-a750-c8b26750eb3a)
^ Newsfeed skeleton

See the `skeletons` folder for more details on how it was implemented.

## style(Footer): added mt & email support link
This was to fix the issue of the Footer sticking with the Stock Screener and the Newsfeed in the dashboard. I just forgot to add a margin-top in pull request #1 . 

![image](https://github.com/user-attachments/assets/f09a58d7-c0fa-440b-9bbc-9ed5499f71e5)
The hyperlink leads to my gmail. I will actively watch my inbox after we announce the deployment of this platform.
I have ensured the footer remains consistent in Mobile view.