### PR TITLE
Feat/market status bar

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -1,23 +1,38 @@
 <!doctype html>
 <html lang="en">
-	<head>
-		<meta charset="UTF-8" />
-		<link rel="icon" href="/Logo_white.svg" />
-		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
-		<!-- Preview text and image for social media -->
-		<meta property="og:title" content="Stockish" />
-		<meta
-			property="og:description"
-			content="Learn how to trade stocks with Stockish!"
-		/>
-		<meta property="og:image" content="/Stockish Embed.png" />
-		<meta property="og:image:type" content="image/png" />
-		<meta property="og:image:width" content="1918" />
-		<meta property="og:image:height" content="963" />
-		<title>Stockish</title>
-	</head>
-	<body>
-		<div id="root"></div>
-		<script type="module" src="/src/main.tsx"></script>
-	</body>
+    <head>
+        <meta charset="UTF-8" />
+        <link rel="icon" href="/Logo_white.svg" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        
+        <!-- basic SEO -->
+        <title>Stockish — Learn Stock Trading</title>
+        <meta name="description" content="Learn how to trade stocks with Stockish - A platform to practice stock trading in a risk-free environment." />
+        
+        <!-- open graph embed -->
+        <meta property="og:type" content="website" />
+        <meta property="og:url" content="https://stockish.vercel.app" />
+        <meta property="og:site_name" content="Stockish" />
+        <meta property="og:title" content="Stockish — Learn Stock Trading" />
+        <meta property="og:description" content="Learn how to trade stocks with Stockish - A platform to practice stock trading in a risk-free environment." />
+        <meta property="og:image" content="https://stockish.vercel.app/Stockish Embed.png" />
+        <meta property="og:image:type" content="image/png" />
+        <meta property="og:image:width" content="1200" />
+        <meta property="og:image:height" content="630" />
+        
+        <!-- Twitter embed -->
+        <meta name="twitter:card" content="summary_large_image" />
+        <meta name="twitter:site" content="@stockish" />
+        <meta name="twitter:creator" content="@stockish" />
+        <meta name="twitter:title" content="Stockish — Learn Stock Trading" />
+        <meta name="twitter:description" content="Learn how to trade stocks with Stockish - A platform to practice stock trading in a risk-free environment." />
+        <meta name="twitter:image" content="https://stockish.vercel.app/Stockish Embed.png" />
+        
+        <!-- theme color -->
+        <meta name="theme-color" content="#2962FF" />
+    </head>
+    <body>
+        <div id="root"></div>
+        <script type="module" src="/src/main.tsx"></script>
+    </body>
 </html>

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -1,5 +1,6 @@
 import React, { lazy, Suspense } from "react";
 import Navbar from "./components/Navbar";
+import MarketStatusBar from "./components/MarketStatusBar";
 import { Container, Box, Spacer, Text, Link, Spinner } from "@chakra-ui/react";
 import { Route, Routes } from "react-router-dom";
 const Dashboard = lazy(() => import("./pages/Dashboard"));
@@ -47,6 +48,7 @@ function App() {
 	return (
 		<>
 			<Navbar />
+			 <MarketStatusBar />
 			<Container maxW="container.90vw">
 				<Spacer h="10" />
 				<Box>

--- a/app/src/components/MarketStatusBar.tsx
+++ b/app/src/components/MarketStatusBar.tsx
@@ -1,0 +1,64 @@
+import React, { useState, useEffect } from 'react';
+import { Box, Text, CloseButton, Flex } from '@chakra-ui/react';
+
+const MarketStatusBar = () => {
+  const [isMarketClosed, setIsMarketClosed] = useState(true);
+  const [isVisible, setIsVisible] = useState(true);
+
+  const checkMarketStatus = () => {
+    const now = new Date();
+    const nyTime = new Date(now.toLocaleString('en-US', { timeZone: 'America/New_York' })); // use newyork time
+    const day = nyTime.getDay();
+    const hour = nyTime.getHours();
+    const minute = nyTime.getMinutes();
+    const currentTime = hour * 60 + minute;
+
+    // checks if it's weekend
+    if (day === 0 || day === 6) {
+      setIsMarketClosed(true);
+      return;
+    }
+
+    // market hours: 9:30 AM - 4:00 PM ET
+    const marketOpen = 9 * 60 + 30;
+    const marketClose = 16 * 60;
+
+    setIsMarketClosed(currentTime < marketOpen || currentTime >= marketClose);
+  };
+
+  useEffect(() => {
+    checkMarketStatus();
+    const interval = setInterval(checkMarketStatus, 60000); // checks every minute
+    return () => clearInterval(interval);
+  }, []);
+
+  if (!isVisible || !isMarketClosed) return null;
+
+  return (
+    <Box
+      bg="linear-gradient(90deg,rgb(250, 230, 115) 0%,rgb(248, 188, 75) 100%)"
+      p={1}
+      position="relative"
+    >
+      <Flex align="center" justify="center">
+        <Text 
+          color="white"
+          fontWeight="medium" 
+          textAlign="center"
+          fontSize="sm"
+          mr={8}
+        >
+          The stock market is closed - Portfolio values may not update
+        </Text>
+        <CloseButton
+          size="sm"
+          color="white"
+          onClick={() => setIsVisible(false)}
+          _hover={{ opacity: 0.8 }}
+        />
+      </Flex>
+    </Box>
+  );
+};
+
+export default MarketStatusBar;


### PR DESCRIPTION
Added a market status bar. It is connected to the NYSE and NASDAQ (New York ET) timezones. 
Timings are:
`9:30 a.m. ET and closes at 4:00 p.m. ET, Monday through Friday`.

![image](https://github.com/user-attachments/assets/40369151-0ed0-47b7-8fb7-99e553adce2e)

It displays on all pages until the user chooses to close it. 