### PR TITLE
fix(HeroPage): resize line_vector_1_light.svg

### DIFF
--- a/app/src/pages/HeroPage.tsx
+++ b/app/src/pages/HeroPage.tsx
@@ -79,9 +79,9 @@ export default function HeroPage() {
       <Box
         position="absolute"
         top="30%"
-        left="50%"
+        left="40%"
         transform="translateX(-50%)"
-        width="140vw"
+        width="160vw"
         height="auto"
         zIndex={0}
         opacity={0.5}>


### PR DESCRIPTION
resized & repositioned line vector 1 to remove the awkward cutoff

![image](https://github.com/user-attachments/assets/97df86e1-a5be-4bac-a669-a587ca843766)
![image](https://github.com/user-attachments/assets/ac581030-e03c-443b-b340-0310015f48ab)
